### PR TITLE
Use unsigned release for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,5 +29,5 @@ jobs:
     - name: Upload Release APK
       uses: actions/upload-artifact@v3
       with:
-        name: ark-rate-release
-        path: ./app/build/outputs/apk/release/ark-rate-release.apk
+        name: ark-rate
+        path: ./app/build/outputs/apk/release/ark-rate-release-unsigned.apk

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,16 +34,6 @@ android {
             }
         }
     }
-    signingConfigs {
-        testRelease {
-            storeFile project.rootProject.file('./testRelease.jks')
-            storePassword "arkrate"
-            keyAlias "key0"
-            keyPassword "arkrate"
-            v1SigningEnabled true
-            v2SigningEnabled true
-        }
-    }
 
     buildTypes {
         debug {
@@ -56,7 +46,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.testRelease
+
             manifestPlaceholders = [
                     appIcon : "@mipmap/ic_launcher",
                     appLabel: "@string/app_name"


### PR DESCRIPTION
After I've removed `testRelease.jks` all builds fail because test release cannot be signed.

This PR removes automated signing. Test builds should be uploaded to artifacts as unsigned APKs.

How to automate signing for Release workflow? See `.github/workflows/release.yml`
I'm afraid we cannot do it with standard GitHub tools.