### PR TITLE
Fixes for Play Protect alarm

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
         buildConfigField "String", "ACRA_LOGIN", "\"$login\""
         buildConfigField "String", "ACRA_PASS", "\"$password\""
         buildConfigField "String", "ACRA_URI", "\"$uri\""
-        buildConfigField "boolean", "GOOGLE_PLAY_BUILD", "true"
+        buildConfigField "boolean", "GOOGLE_PLAY_BUILD", "false"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ android {
         buildConfigField "String", "ACRA_LOGIN", "\"$login\""
         buildConfigField "String", "ACRA_PASS", "\"$password\""
         buildConfigField "String", "ACRA_URI", "\"$uri\""
+        buildConfigField "boolean", "GOOGLE_PLAY_BUILD", "true"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/App.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/App.kt
@@ -29,7 +29,9 @@ class App : Application() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
         DIManager.init(this)
-        initAcra()
+        
+        if (!BuildConfig.GOOGLE_PLAY_BUILD)
+            initAcra()
 
         initWorker()
     }

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/pairalert/PairAlertConditionScreen.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/pairalert/PairAlertConditionScreen.kt
@@ -14,12 +14,14 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -31,16 +33,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import dev.arkbuilders.rate.R
 import dev.arkbuilders.rate.data.model.PairAlertCondition
 import dev.arkbuilders.rate.presentation.destinations.AddCurrencyScreenDestination
 import dev.arkbuilders.rate.presentation.destinations.PairAlertConditionScreenDestination
 import dev.arkbuilders.rate.presentation.shared.SharedViewModel
+import dev.arkbuilders.rate.presentation.theme.Purple500
 import dev.arkbuilders.rate.presentation.utils.activityViewModel
 import dev.arkbuilders.rate.utils.removeFractionalPartIfEmpty
 
@@ -50,8 +59,27 @@ fun PairAlertConditionScreen(
     navigator: DestinationsNavigator,
     viewModel: SharedViewModel = activityViewModel()
 ) {
+    var descDialog by remember { mutableStateOf(false) }
+
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(modifier = Modifier.fillMaxSize()) {
+            item {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.CenterEnd
+                ) {
+                    IconButton(
+                        modifier = Modifier.padding(top = 16.dp, end = 8.dp),
+                        onClick = { descDialog = true }
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_question_mark),
+                            contentDescription = "",
+                            tint = Purple500
+                        )
+                    }
+                }
+            }
             items(
                 viewModel.pairAlertConditions,
                 key = { it.id }
@@ -63,6 +91,11 @@ fun PairAlertConditionScreen(
             }
         }
     }
+
+    if (descDialog)
+        DescDialog {
+            descDialog = false
+        }
 }
 
 @Composable
@@ -203,6 +236,33 @@ private fun AddOrDeleteBtn(
             }
         ) {
             Icon(Icons.Filled.Delete, "Delete")
+        }
+    }
+}
+
+@Composable
+private fun DescDialog(onDismiss: () -> Unit) {
+    Dialog(onDismissRequest = { onDismiss() }) {
+        Surface(
+            shape = RoundedCornerShape(20.dp),
+            color = Color.White
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = stringResource(R.string.pair_alerts_desc),
+                    textAlign = TextAlign.Center
+                )
+                Button(
+                    modifier = Modifier.padding(top = 10.dp),
+                    onClick = { onDismiss() }) {
+                    Text(text = stringResource(R.string.ok))
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/settings/SettingsScreen.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/settings/SettingsScreen.kt
@@ -60,8 +60,6 @@ import dev.arkbuilders.rate.R
 import dev.arkbuilders.rate.data.preferences.PreferenceKey
 import dev.arkbuilders.rate.di.DIManager
 
-private val PRIVACY_POLICY_URL = "https://app-privacy-policy-generator.firebaseapp.com/"
-
 @Destination
 @Composable
 fun SettingsScreen() {
@@ -69,10 +67,7 @@ fun SettingsScreen() {
         viewModel(factory = DIManager.component.settingsVMFactory())
 
     if (vm.initialized) {
-        Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-            Settings(Modifier.weight(1f), vm)
-            PrivacyPolicy()
-        }
+        Settings(vm)
     } else {
         Box(modifier = Modifier.fillMaxSize()) {
             CircularProgressIndicator()
@@ -83,23 +78,35 @@ fun SettingsScreen() {
 @Composable
 private fun PrivacyPolicy() {
     val ctx = LocalContext.current
-    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-        Text(
-            modifier = Modifier.clickable {
-                val intent = Intent(Intent.ACTION_VIEW)
-                intent.data = Uri.parse(PRIVACY_POLICY_URL)
-                ctx.startActivity(intent)
-            },
-            text = "Privacy policy",
-            textDecoration = TextDecoration.Underline
-        )
+    val url = stringResource(id = R.string.privacy_policy_url)
+    Surface(
+        color = Color.Transparent,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        onClick = {
+            val intent = Intent(Intent.ACTION_VIEW)
+            intent.data = Uri.parse(url)
+            ctx.startActivity(intent)
+        },
+    ) {
+        Column {
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = stringResource(id = R.string.privacy_policy),
+                style = MaterialTheme.typography.body1,
+            )
+            Divider()
+        }
+
     }
 }
 
 @Composable
-private fun Settings(modifier: Modifier = Modifier, vm: SettingsViewModel) {
+private fun Settings(vm: SettingsViewModel) {
     Column(
-        modifier = modifier
+        modifier = Modifier
+            .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
         SettingsGroup(name = R.string.currencies) {
@@ -143,8 +150,9 @@ private fun Settings(modifier: Modifier = Modifier, vm: SettingsViewModel) {
                 onCheck = { true }
             )
         }
-        if (!BuildConfig.GOOGLE_PLAY_BUILD) {
-            SettingsGroup(name = R.string.privacy) {
+        SettingsGroup(name = R.string.privacy) {
+            PrivacyPolicy()
+            if (!BuildConfig.GOOGLE_PLAY_BUILD) {
                 SettingsSwitchComp(
                     name = R.string.crash_reports,
                     state = vm.boolPrefs[PreferenceKey.CrashReport]!!
@@ -274,7 +282,7 @@ fun SettingsNumberComp(
                         modifier = Modifier.size(24.dp)
                     )
                 }
-                Spacer(modifier = Modifier.width(16.dp))
+                Spacer(modifier = Modifier.width(8.dp))
                 Column(modifier = Modifier.padding(8.dp)) {
                     Text(
                         text = stringResource(id = name),

--- a/app/src/main/res/drawable/ic_question_mark.xml
+++ b/app/src/main/res/drawable/ic_question_mark.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11.07,12.85c0.77,-1.39 2.25,-2.21 3.11,-3.44c0.91,-1.29 0.4,-3.7 -2.18,-3.7c-1.69,0 -2.52,1.28 -2.87,2.34L6.54,6.96C7.25,4.83 9.18,3 11.99,3c2.35,0 3.96,1.07 4.78,2.41c0.7,1.15 1.11,3.3 0.03,4.9c-1.2,1.77 -2.35,2.31 -2.97,3.45c-0.25,0.46 -0.35,0.76 -0.35,2.24h-2.89C10.58,15.22 10.46,13.95 11.07,12.85zM14,20c0,1.1 -0.9,2 -2,2s-2,-0.9 -2,-2c0,-1.1 0.9,-2 2,-2S14,18.9 14,20z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
     <string name="show_as_list">List</string>
     <string name="sorted_by_used_count">Used count</string>
     <string name="sorted_by_used_time">Used time</string>
+    <string name="pair_alerts_desc">App in the background checks the specified exchange rates once a day and if the condition matches, then displays a notification.</string>
+    <string name="ok">OK</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,6 @@
     <string name="sorted_by_used_time">Used time</string>
     <string name="pair_alerts_desc">App in the background checks the specified exchange rates once a day and if the condition matches, then displays a notification.</string>
     <string name="ok">OK</string>
-    <string name="privacy_policy_url" translatable="false">https://app-privacy-policy-generator.firebaseapp.com/</string>
+    <string name="privacy_policy_url" translatable="false">https://www.ark-builders.dev/apps/rate/privacy-policy</string>
     <string name="privacy_policy">Privacy policy</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,4 +21,6 @@
     <string name="sorted_by_used_time">Used time</string>
     <string name="pair_alerts_desc">App in the background checks the specified exchange rates once a day and if the condition matches, then displays a notification.</string>
     <string name="ok">OK</string>
+    <string name="privacy_policy_url" translatable="false">https://app-privacy-policy-generator.firebaseapp.com/</string>
+    <string name="privacy_policy">Privacy policy</string>
 </resources>


### PR DESCRIPTION
- Added privacy policy, [it looks like it's still required since assets can be considered sensitive data](https://support.google.com/googleplay/android-developer/answer/9859455?hl=en)
- Removed crash reporting for Google Play build. From the user's point of view, this may be a deception, since the crash will still be collected by Google, even if the setting is turned off
- Added description for pair alerts, this is a background job that can be considered hidden/undocumented feature. Or moreover, user may think that the app will check exchange rates every 5 minutes for example and not once a day