### PR TITLE
Fix create new pair instead of updating current one

### DIFF
--- a/app/src/main/java/dev/arkbuilders/rate/presentation/quick/AddQuickScreen.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/quick/AddQuickScreen.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package dev.arkbuilders.rate.presentation.quick
 
 import androidx.compose.foundation.BorderStroke
@@ -21,7 +19,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/quick/AddQuickViewModel.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/quick/AddQuickViewModel.kt
@@ -73,7 +73,7 @@ class AddQuickViewModel(
             intent {
                 val newAmounts = state.currencies + AmountStr(code, "")
                 val calc = calcToResult(newAmounts)
-                reduce {  state.copy(currencies = calc) }
+                reduce { state.copy(currencies = calc) }
                 checkFinishEnabled()
             }
         }.launchIn(viewModelScope)
@@ -134,7 +134,7 @@ class AddQuickViewModel(
     fun onAddQuickPair() = intent {
         val from = state.currencies.first()
         val quick = QuickPair(
-            id = 0,
+            id = quickPairId ?: 0,
             from = from.code,
             amount = from.value.toDouble(),
             to = state.currencies.drop(1).map { it.code },

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/quick/AddQuickViewModel.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/quick/AddQuickViewModel.kt
@@ -17,7 +17,6 @@ import dev.arkbuilders.rate.domain.repo.AnalyticsManager
 import dev.arkbuilders.rate.domain.repo.CodeUseStatRepo
 import dev.arkbuilders.rate.domain.repo.QuickRepo
 import dev.arkbuilders.rate.domain.usecase.ConvertWithRateUseCase
-import dev.arkbuilders.rate.presentation.search.SearchViewModelFactory
 import dev.arkbuilders.rate.presentation.shared.AppSharedFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -28,8 +27,6 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import javax.inject.Inject
-import javax.inject.Singleton
 
 data class AddQuickScreenState(
     val quickPairId: Long? = null,

--- a/app/src/main/java/dev/arkbuilders/rate/presentation/quick/QuickScreen.kt
+++ b/app/src/main/java/dev/arkbuilders/rate/presentation/quick/QuickScreen.kt
@@ -1,5 +1,4 @@
 @file:OptIn(
-    ExperimentalComposeUiApi::class,
     ExperimentalFoundationApi::class
 )
 
@@ -34,7 +33,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color


### PR DESCRIPTION
## Summary
Currently, when create new pair, then update it, the app creates new pairs instead of current one. It should be an update operation
Steps to reproduce:
1. Create new pair
2. Long click on the pair
3. Change currency
4. Press save

## Changes
Instead of using default Id as 0, use selected pairId to update existing pair

**Before**

https://github.com/ARK-Builders/ARK-Rate/assets/43868345/ac020dbe-105b-4179-89f7-07faa4347d29


**After**

https://github.com/ARK-Builders/ARK-Rate/assets/43868345/473af9fc-8bb2-40cc-9afc-c07f7c865b0a

