### PR TITLE
Update widget by group when it is first added

### DIFF
--- a/feature/quickwidget/src/main/java/dev/arkbuilders/rate/feature/quickwidget/presentation/QuickPairsWidgetReceiver.kt
+++ b/feature/quickwidget/src/main/java/dev/arkbuilders/rate/feature/quickwidget/presentation/QuickPairsWidgetReceiver.kt
@@ -46,15 +46,13 @@ class QuickPairsWidgetReceiver : GlanceAppWidgetReceiver() {
             GlanceAppWidgetManager(context)
                 .getGlanceIds(QuickPairsWidget::class.java)
                 .forEach { glanceId ->
-                    QuickPairsWidgetReceiver.run {
-                        updateWidgetNewGroup(
-                            context = context,
-                            glanceId = glanceId,
-                            findNewIndex = { _, _ ->
-                                0
-                            },
-                        )
-                    }
+                    updateWidgetNewGroup(
+                        context = context,
+                        glanceId = glanceId,
+                        findNewIndex = { currentIndex, _ ->
+                            currentIndex ?: 0
+                        },
+                    )
                 }
         }
     }
@@ -78,8 +76,9 @@ class QuickPairsWidgetReceiver : GlanceAppWidgetReceiver() {
                     }
                 if (currentIndex == -1)
                     currentIndex = null
+
                 val newIndex = findNewIndex(currentIndex, allGroups.lastIndex)
-                val newGroup = allGroups[newIndex]
+                val newGroup = allGroups.getOrNull(newIndex)
                 if (newGroup != null) {
                     prefs[currentGroupIdKey] = newGroup.id
                 } else {

--- a/feature/quickwidget/src/main/java/dev/arkbuilders/rate/feature/quickwidget/presentation/QuickPairsWidgetReceiver.kt
+++ b/feature/quickwidget/src/main/java/dev/arkbuilders/rate/feature/quickwidget/presentation/QuickPairsWidgetReceiver.kt
@@ -46,7 +46,15 @@ class QuickPairsWidgetReceiver : GlanceAppWidgetReceiver() {
             GlanceAppWidgetManager(context)
                 .getGlanceIds(QuickPairsWidget::class.java)
                 .forEach { glanceId ->
-                    glanceAppWidget.update(context, glanceId)
+                    QuickPairsWidgetReceiver.run {
+                        updateWidgetNewGroup(
+                            context = context,
+                            glanceId = glanceId,
+                            findNewIndex = { _, _ ->
+                                0
+                            },
+                        )
+                    }
                 }
         }
     }


### PR DESCRIPTION
**Description**
Currently, when add widget the first time, widget content is empty.

**Cause**
This is because of missing default loading of first page of group.

**Solution**
Fixed by adding the code to load when widget first added