### PR TITLE
Prevent invalid quick calculations and clarify calculation history

### DIFF
--- a/core/presentation/src/main/res/values-ru/strings.xml
+++ b/core/presentation/src/main/res/values-ru/strings.xml
@@ -19,7 +19,7 @@
     <string name="quick_edit_calc">Редактировать расчёт</string>
     <string name="quick_last_refreshed_ago">Последнее обновление %1$s назад</string>
     <string name="quick_last_refreshed_now">Обновлено только что</string>
-    <string name="quick_calculations">Расчеты</string>
+    <string name="quick_history">История расчётов</string>
     <string name="quick_pinned_calculations">Закрепленные расчеты</string>
     <string name="quick_calculated_ago">Рассчитано %1$s назад</string>
     <string name="quick_calculated_on">Рассчитано на %1$s</string>

--- a/core/presentation/src/main/res/values/strings.xml
+++ b/core/presentation/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
     <string name="quick_edit_calc">Edit calculation</string>
     <string name="quick_last_refreshed_ago">Last refreshed %1$s ago</string>
     <string name="quick_last_refreshed_now">Updated just now</string>
-    <string name="quick_calculations">Calculations</string>
+    <string name="quick_history">Calculation history</string>
     <string name="quick_pinned_calculations">Pinned calculations</string>
     <string name="quick_calculated_ago">Calculated %1$s ago</string>
     <string name="quick_calculated_on">Calculated on %1$s</string>

--- a/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/quickcalculation/OnboardingQuickCalculationScreen.kt
+++ b/feature/onboarding/src/main/java/dev/arkbuilders/rate/feature/onboarding/quickcalculation/OnboardingQuickCalculationScreen.kt
@@ -172,7 +172,7 @@ fun OnboardingQuickCalculationScreen(navigator: DestinationsNavigator) {
                     },
             ) {
                 if (state.stepIndex <= 1) {
-                    ListHeader(text = stringResource(CoreRString.quick_calculations))
+                    ListHeader(text = stringResource(CoreRString.quick_history))
                 } else {
                     ListHeader(text = stringResource(CoreRString.quick_pinned_calculations))
                 }

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/domain/usecase/CleanupInvalidQuickCalculationsUseCase.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/domain/usecase/CleanupInvalidQuickCalculationsUseCase.kt
@@ -1,0 +1,20 @@
+package dev.arkbuilders.rate.feature.quick.domain.usecase
+
+import dev.arkbuilders.rate.core.domain.repo.AnalyticsManager
+import dev.arkbuilders.rate.feature.quick.domain.repo.QuickRepo
+import javax.inject.Inject
+
+class CleanupInvalidQuickCalculationsUseCase @Inject constructor(
+    private val quickRepo: QuickRepo,
+    private val analyticsManager: AnalyticsManager,
+) {
+    suspend operator fun invoke() {
+        quickRepo.getAll()
+            .filter { it.to.isEmpty() }
+            .forEach { calculation ->
+                if (quickRepo.delete(calculation.id)) {
+                    analyticsManager.logEvent("quick_invalid_calculation_removed")
+                }
+            }
+    }
+}

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/domain/usecase/ValidateQuickCalculationUseCase.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/domain/usecase/ValidateQuickCalculationUseCase.kt
@@ -1,0 +1,27 @@
+package dev.arkbuilders.rate.feature.quick.domain.usecase
+
+import dev.arkbuilders.rate.core.domain.model.AmountStr
+import dev.arkbuilders.rate.core.domain.repo.AnalyticsManager
+import dev.arkbuilders.rate.core.domain.toDoubleArk
+import javax.inject.Inject
+
+class ValidateQuickCalculationUseCase @Inject constructor(
+    private val analyticsManager: AnalyticsManager,
+) {
+    operator fun invoke(
+        currencies: List<AmountStr>,
+        sendAnalyticsEvent: Boolean = false,
+    ): Boolean {
+        val from = currencies.firstOrNull()
+        val isValid =
+            from != null &&
+                currencies.size > 1 &&
+                from.value.toDoubleArk() != 0.0
+
+        if (isValid.not() && sendAnalyticsEvent) {
+            analyticsManager.logEvent("add_quick_invalid_calculation_attempt")
+        }
+
+        return isValid
+    }
+}

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickViewModel.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickViewModel.kt
@@ -15,11 +15,11 @@ import dev.arkbuilders.rate.core.domain.repo.AnalyticsManager
 import dev.arkbuilders.rate.core.domain.repo.CodeUseStatRepo
 import dev.arkbuilders.rate.core.domain.repo.GroupRepo
 import dev.arkbuilders.rate.core.domain.toBigDecimalArk
-import dev.arkbuilders.rate.core.domain.toDoubleArk
 import dev.arkbuilders.rate.core.domain.usecase.ConvertWithRateUseCase
 import dev.arkbuilders.rate.core.domain.usecase.GetGroupByIdOrCreateDefaultUseCase
 import dev.arkbuilders.rate.feature.quick.domain.model.QuickCalculation
 import dev.arkbuilders.rate.feature.quick.domain.repo.QuickRepo
+import dev.arkbuilders.rate.feature.quick.domain.usecase.ValidateQuickCalculationUseCase
 import dev.arkbuilders.rate.feature.search.presentation.SearchNavResult
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
@@ -62,6 +62,7 @@ class AddQuickViewModel(
     private val convertUseCase: ConvertWithRateUseCase,
     private val getGroupByIdOrCreateDefaultUseCase: GetGroupByIdOrCreateDefaultUseCase,
     private val codeUseStatRepo: CodeUseStatRepo,
+    private val validateQuickCalculationUseCase: ValidateQuickCalculationUseCase,
     private val analyticsManager: AnalyticsManager,
 ) : ViewModel(), ContainerHost<AddQuickScreenState, AddQuickScreenEffect> {
     override val container: Container<AddQuickScreenState, AddQuickScreenEffect> =
@@ -219,12 +220,16 @@ class AddQuickViewModel(
     fun onAddQuickCalculation() =
         intent {
             val currencies = state.currencies
-            val from = currencies.firstOrNull() ?: return@intent
-            val to = currencies.drop(1)
-
-            if (to.isEmpty() || from.value.toDoubleArk() == 0.0) {
+            if (
+                validateQuickCalculationUseCase(
+                    currencies = currencies,
+                    sendAnalyticsEvent = true,
+                ).not()
+            ) {
                 return@intent
             }
+            val from = currencies.first()
+            val to = currencies.drop(1)
 
             val id =
                 if (quickCalculationId != null) {
@@ -285,19 +290,10 @@ class AddQuickViewModel(
 
     private fun checkFinishEnabled() =
         intent {
-            val from = state.currencies.first()
-            val to = state.currencies.drop(1)
-
-            var finishEnabled = true
-
-            if (from.value.toDoubleArk() == 0.0)
-                finishEnabled = false
-
-            if (to.isEmpty())
-                finishEnabled = false
-
             reduce {
-                state.copy(finishEnabled = finishEnabled)
+                state.copy(
+                    finishEnabled = validateQuickCalculationUseCase(state.currencies),
+                )
             }
         }
 
@@ -335,6 +331,7 @@ class AddQuickViewModelFactory @AssistedInject constructor(
     private val codeUseStatRepo: CodeUseStatRepo,
     private val getGroupByIdOrCreateDefaultUseCase: GetGroupByIdOrCreateDefaultUseCase,
     private val convertUseCase: ConvertWithRateUseCase,
+    private val validateQuickCalculationUseCase: ValidateQuickCalculationUseCase,
     private val analyticsManager: AnalyticsManager,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -348,6 +345,7 @@ class AddQuickViewModelFactory @AssistedInject constructor(
             convertUseCase,
             getGroupByIdOrCreateDefaultUseCase,
             codeUseStatRepo,
+            validateQuickCalculationUseCase,
             analyticsManager,
         ) as T
     }

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickViewModel.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickViewModel.kt
@@ -88,10 +88,10 @@ class AddQuickViewModel(
                         currencies = calc,
                         group = quickCalculation.group,
                         availableGroups = groups,
+                        finishEnabled = validateQuickCalculationUseCase(calc),
                         initialized = true,
                     )
                 }
-                checkFinishEnabled()
             } ?: let {
                 val group = getGroupByIdOrCreateDefaultUseCase(groupId, GroupFeatureType.Quick)
                 val currencies =
@@ -122,8 +122,12 @@ class AddQuickViewModel(
         intent {
             val newAmounts = state.currencies + AmountStr(code, "")
             val calc = calcToResult(newAmounts)
-            reduce { state.copy(currencies = calc) }
-            checkFinishEnabled()
+            reduce {
+                state.copy(
+                    currencies = calc,
+                    finishEnabled = validateQuickCalculationUseCase(calc),
+                )
+            }
         }
 
     private fun handleNavResSetCode(
@@ -140,14 +144,15 @@ class AddQuickViewModel(
     fun onCurrencyRemove(removeIndex: Int) =
         intent {
             analyticsManager.logEvent("add_quick_currency_removed")
+            val currencies =
+                state.currencies
+                    .filterIndexed { index, _ -> index != removeIndex }
             reduce {
                 state.copy(
-                    currencies =
-                        state.currencies
-                            .filterIndexed { index, _ -> index != removeIndex },
+                    currencies = currencies,
+                    finishEnabled = validateQuickCalculationUseCase(currencies),
                 )
             }
-            checkFinishEnabled()
         }
 
     fun onGroupSelect(group: Group) =
@@ -180,8 +185,12 @@ class AddQuickViewModel(
             val from = state.currencies.first()
             val new = from.copy(value = CurrUtils.validateInput(from.value, input))
             val calc = calcToResult(listOf(new) + state.currencies.drop(1))
-            reduce { state.copy(currencies = calc) }
-            checkFinishEnabled()
+            reduce {
+                state.copy(
+                    currencies = calc,
+                    finishEnabled = validateQuickCalculationUseCase(calc),
+                )
+            }
         }
 
     fun onSwapClick() =
@@ -287,15 +296,6 @@ class AddQuickViewModel(
             }
         return listOf(from) + new
     }
-
-    private fun checkFinishEnabled() =
-        intent {
-            reduce {
-                state.copy(
-                    finishEnabled = validateQuickCalculationUseCase(state.currencies),
-                )
-            }
-        }
 
     fun onSetCode(index: Int) =
         intent {

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickViewModel.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/add/AddQuickViewModel.kt
@@ -218,7 +218,14 @@ class AddQuickViewModel(
 
     fun onAddQuickCalculation() =
         intent {
-            val from = state.currencies.first()
+            val currencies = state.currencies
+            val from = currencies.firstOrNull() ?: return@intent
+            val to = currencies.drop(1)
+
+            if (to.isEmpty() || from.value.toDoubleArk() == 0.0) {
+                return@intent
+            }
+
             val id =
                 if (quickCalculationId != null) {
                     if (reuseNotEdit) 0 else quickCalculationId
@@ -247,7 +254,7 @@ class AddQuickViewModel(
                     id = id,
                     from = from.code,
                     amount = from.value.toBigDecimalArk(),
-                    to = state.currencies.drop(1).map { it.toAmount() },
+                    to = to.map { it.toAmount() },
                     calculatedDate = OffsetDateTime.now(),
                     pinnedDate = pinnedDate,
                     group = group,

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickScreen.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickScreen.kt
@@ -350,7 +350,7 @@ private fun GroupPage(
         }
         if (notPinned.isNotEmpty()) {
             item {
-                ListHeader(text = stringResource(CoreRString.quick_calculations))
+                ListHeader(text = stringResource(CoreRString.quick_history))
             }
             items(notPinned, key = { it.id }) {
                 QuickSwipeItem(

--- a/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickViewModel.kt
+++ b/feature/quick/src/main/java/dev/arkbuilders/rate/feature/quick/presentation/main/QuickViewModel.kt
@@ -25,6 +25,7 @@ import dev.arkbuilders.rate.core.presentation.ui.group.EditGroupReorderSheetStat
 import dev.arkbuilders.rate.feature.quick.domain.model.PinnedQuickCalculation
 import dev.arkbuilders.rate.feature.quick.domain.model.QuickCalculation
 import dev.arkbuilders.rate.feature.quick.domain.repo.QuickRepo
+import dev.arkbuilders.rate.feature.quick.domain.usecase.CleanupInvalidQuickCalculationsUseCase
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -85,6 +86,7 @@ class QuickViewModel(
     private val searchUseCase: SearchUseCase,
     private val analyticsManager: AnalyticsManager,
     private val prefs: Prefs,
+    private val cleanupInvalidQuickCalculationsUseCase: CleanupInvalidQuickCalculationsUseCase,
 ) : ViewModel(), ContainerHost<QuickScreenState, QuickScreenEffect> {
     override val container: Container<QuickScreenState, QuickScreenEffect> =
         container(QuickScreenState())
@@ -95,6 +97,8 @@ class QuickViewModel(
 
     private fun init() =
         intent {
+            cleanupInvalidQuickCalculationsUseCase()
+
             quickRepo.allFlow().drop(1).onEach {
                 intent {
                     val pages = buildPages()
@@ -423,6 +427,7 @@ class QuickViewModelFactory @AssistedInject constructor(
     private val searchUseCase: SearchUseCase,
     private val analyticsManager: AnalyticsManager,
     private val prefs: Prefs,
+    private val cleanupInvalidQuickCalculationsUseCase: CleanupInvalidQuickCalculationsUseCase,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return QuickViewModel(
@@ -436,6 +441,7 @@ class QuickViewModelFactory @AssistedInject constructor(
             searchUseCase,
             analyticsManager,
             prefs,
+            cleanupInvalidQuickCalculationsUseCase,
         ) as T
     }
 


### PR DESCRIPTION
## 📌 Description
- Prevent invalid quick calculations from being saved
- Add `ValidateQuickCalculationUseCase` as the shared source of validation
- Use the validation use case for both the Save button state and the final save attempt
- Log `add_quick_invalid_calculation_attempt` when an invalid save is attempted
- Rename the unpinned calculations section to `Calculation history`
- Add `CleanupInvalidQuickCalculationsUseCase` to remove previously saved invalid calculations when the Quick screen opens
- Log `quick_invalid_calculation_removed` for each invalid calculation removed
